### PR TITLE
added concierge.css to main property in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,10 @@
         "email": "alxgbsn@gmail.com"
     },
     "keywords": ["javascript", "open web apps", "install", "firefox os"],
-    "main": "./concierge.js",
+    "main": [
+	"./concierge.js",
+	"./concierge.css"
+	],
     "repository": {
         "type": "git",
         "url": "https://github.com/alexgibson/concierge.git"


### PR DESCRIPTION
Hello,

I was working with Concierge and I found that `concierge.ccs` wasn't linked in my html files by wiredep so I added it to the __main__ property and it worked flawlessy. Thanks you for your work!